### PR TITLE
implement configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,15 @@ go get github.com/go-spatial/go-wfs
 ## Running
 
 ```bash
+cd $GOPATH/src/github.com/go-spatial/go-wfs
+# create configuration
+cp go-wfs-config.toml local.toml
+vi local.toml  # update accordingly
+# server.url
+# collections.data
+
 # start server on http://localhost:9000/
-go run main.go  # or go build main.go
+go run main.go local.toml
 ```
 
 

--- a/go-wfs-config.toml
+++ b/go-wfs-config.toml
@@ -1,0 +1,41 @@
+[server]
+  url = "http://localhost:9000/"
+  mimetype = "application/json; charset=UTF-8"
+  encoding = "utf-8"
+  language = "en-US"
+  pretty_print = true
+  limit = 10
+
+[logging]
+  level = "INFO"
+  #logfile = "/tmp/go-wfs.log"
+
+[metadata]
+  [metadata.identification]
+    title = "go-wfs"
+    abstract = "go-wfs is a Go server implementation of OGC WFS 3.0"
+    keywords = [ "geospatial", "features", "collections", "access" ]
+    keywords_type = "theme"
+    fees = "None"
+    accessconstraints = "None"
+    [metadata.provider]
+      name = "Organization Name"
+      url = "https://github.com/go-spatial/go-wfs"
+    [metadata.contact]
+      name = "Lastname, Firstname"
+      position = "Position Title"
+      address = "Mailing Address"
+      city = "City"
+      stateorprovince = "Administrative Area"
+      postalcode = "Zip or Postal Code"
+      country = "Country"
+      phone = "+xx-xxx-xxx-xxxx"
+      fax = "+xx-xxx-xxx-xxxx"
+      email = "you@example.org"
+      url = "Contact URL"
+      hours = "Hours of Service"
+      instructions = "During hours of service.  Off on weekends."
+      role = "pointOfContact"
+
+[collections]
+  data = "test-data/athens-osm-20170921.gpkg"

--- a/main.go
+++ b/main.go
@@ -28,15 +28,26 @@
 package main
 
 import (
+	"fmt"
 	"github.com/go-spatial/go-wfs/provider"
 	"github.com/go-spatial/go-wfs/server"
 	"github.com/go-spatial/tegola/provider/gpkg"
+	"os"
 )
 
 func main() {
+	args := os.Args
+
+	if len(args) == 1 {
+		fmt.Printf("Usage: %v </path/to/config.toml>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	// load config from command line
+	c, err := server.LoadConfigFromFile(os.Args[1])
+
 	// Instantiate a gpkg provider to send to the server.
-	gpkgPath := "test-data/athens-osm-20170921.gpkg"
-	gpkgConfig, err := gpkg.AutoConfig(gpkgPath)
+	gpkgConfig, err := gpkg.AutoConfig(c.Collections.Data)
 	if err != nil {
 		panic(err)
 	}
@@ -47,5 +58,5 @@ func main() {
 
 	p := provider.Provider{Tiler: gpkgProvider}
 
-	server.StartServer(":9000", p)
+	server.StartServer(c, ":9000", p)
 }

--- a/server/config.go
+++ b/server/config.go
@@ -1,7 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 //
 // The MIT License (MIT)
-// Copyright (c) 2018 Jivan Amara
 // Copyright (c) 2018 Tom Kralidis
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -26,25 +25,64 @@
 
 package server
 
-// Provides mappings for URL routes to handler functions.
-
 import (
-	"net/http"
+	"github.com/BurntSushi/toml"
 )
 
-func setUpRoutes(c Config) {
+// Config provides an object model for configuration.
+type Config struct {
+	Server struct {
+		URL         string
+		MimeType    string
+		Encoding    string
+		Language    string
+		PrettyPrint bool
+		Limit       int
+	}
+	Logging struct {
+		Level   string
+		Logfile string
+	}
+	Metadata struct {
+		Identification struct {
+			Title             string
+			Abstract          string
+			Keywords          []string
+			KeywordsType      string
+			Fees              string
+			AccessConstraints string
+		}
+		Provider struct {
+			Name string
+			URL  string
+		}
+		Contact struct {
+			Name            string
+			Position        string
+			Address         string
+			City            string
+			StateOrProvince string
+			PostalCode      string
+			Country         string
+			Phone           string
+			Fax             string
+			Email           string
+			URL             string
+			Hours           string
+			Instructions    string
+			Role            string
+		}
+	}
+	Collections struct {
+		Data string
+	}
+}
 
-	OpenAPISpec := GenOpenAPISpec(c)
-
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { http.Redirect(w, r, "/api", 307) })
-
-	http.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
-		openapiJson(w, r, OpenAPISpec)
-	})
-	http.HandleFunc("/api/conformance", apiConformance)
-	http.HandleFunc("/api/collectionNames", collectionNames)
-	http.HandleFunc("/api/featurePks", featurePks)
-	http.HandleFunc("/api/feature", getFeature)
-	http.HandleFunc("/api/collection", collectionData)
-	http.HandleFunc("/api/feature_set", filteredFeatures)
+// LoadFromFile read YAML into configuration
+func LoadConfigFromFile(tomlFile string) (Config, error) {
+	var config Config
+	if _, err := toml.DecodeFile(tomlFile, &config); err != nil {
+		return config, err
+	}
+	return config, nil
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -36,6 +36,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/go-openapi/spec"
 	"github.com/go-spatial/go-wfs/provider"
 	"github.com/go-spatial/tegola/geom/encoding/geojson"
 	prv "github.com/go-spatial/tegola/provider"
@@ -82,10 +83,10 @@ func apiConformance(w http.ResponseWriter, r *http.Request) {
 }
 
 // --- Return the json-encoded OpenAPI 2 spec for the WFS API available on this instance.
-func openapiJson(w http.ResponseWriter, r *http.Request) {
+func openapiJson(w http.ResponseWriter, r *http.Request, s spec.Swagger) {
 	var jsonSpec []byte
 	var err error
-	jsonSpec, err = OpenApiSpecJson()
+	jsonSpec, err = OpenApiSpecJson(s)
 
 	var status int = 200
 	w.Header().Set("Content-Type", "application/json")

--- a/server/server.go
+++ b/server/server.go
@@ -35,10 +35,10 @@ import (
 
 var Provider provider.Provider
 
-func StartServer(bindAddress string, p provider.Provider) {
+func StartServer(c Config, bindAddress string, p provider.Provider) {
 	fmt.Println("Listening on ", bindAddress)
 	Provider = p
-	setUpRoutes()
+	setUpRoutes(c)
 	err := http.ListenAndServe(bindAddress, nil)
 	if err != nil {
 		panic(fmt.Sprintf("Problem starting web server: %v", err))


### PR DESCRIPTION
This PR add support for defining a configuration (via [TOML](https://en.wikipedia.org/wiki/TOML)) to specify and use configuration directives in go-wfs. Summary of updates:

- user must now specify the configuration as part of running go-wfs
- the configuration format is based on geocatalogo's configuration with some added elements.  The core configuration metadata directives are based on ISO 19115 constructs which support OpenAPI constructs as well
- configuration is passed to the server startup
- the `spec.Swagger` object is set (once) on startup (using some configuration values) and available when calling `/api`