### PR TITLE
Config-use changes & request host as default for generating links.

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func main() {
 
 	flag.StringVar(&bindIp, "b", "127.0.0.1", "IP address for the server to listen on")
 	flag.IntVar(&bindPort, "p", 9000, "port for the server to listen on")
-	flag.StringVar(&serveAddress, "s", "", "IP:Port that connections will see the server at (defaults to bind address)")
+	flag.StringVar(&serveAddress, "s", "", "IP:Port that result urls will be constructed with (defaults to the IP:Port used in request)")
 	flag.StringVar(&dataSource, "d", "", "data source (path to .gpkg file)")
 	flag.StringVar(&configFile, "c", "", "config (path to .toml file)")
 
@@ -109,13 +109,6 @@ func main() {
 
 	config.Configuration.Server.BindHost = bindIp
 	config.Configuration.Server.BindPort = bindPort
-
-	bindAddress := fmt.Sprintf("%v:%v", bindIp, bindPort)
-
-	if serveAddress == "" {
-		serveAddress = bindAddress
-	}
-
 	config.Configuration.Server.Address = serveAddress
 
 	if dataSource != "" {
@@ -143,5 +136,5 @@ func main() {
 	p := data_provider.Provider{Tiler: dataProvider}
 	wfs3.GenerateOpenAPIDocument()
 
-	server.StartServer(bindAddress, serveAddress, p)
+	server.StartServer(p)
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -150,7 +150,6 @@ func root(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("%v", err)
 		jsonError(w, "response doesn't match schema", 500)
-		log.Printf("*** DELETEME\n---\n%v\n---\n", string(encodedContent))
 		return
 	}
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -35,6 +35,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/go-spatial/go-wfs/config"
 	"github.com/go-spatial/go-wfs/wfs3"
 	"github.com/go-spatial/tegola/geom"
 	"github.com/go-spatial/tegola/geom/encoding/geojson"
@@ -50,6 +51,15 @@ const (
 
 type HandlerError struct {
 	Details string `json:"detail"`
+}
+
+func serveAddress(r *http.Request) string {
+	psa := config.Configuration.Server.Address
+	if psa == "" {
+		psa = r.URL.Host
+	}
+
+	return psa
 }
 
 // contentType() returns the Content-Type string that will be used for the response to this request.
@@ -112,7 +122,7 @@ func root(w http.ResponseWriter, r *http.Request) {
 	// This allows tests to set the result to whatever they want.
 	overrideContent := r.Context().Value("overrideContent")
 
-	rootContent := wfs3.Root(serveAddress)
+	rootContent := wfs3.Root(serveAddress(r))
 	ct := contentType(r)
 	rootContent.ContentType(ct)
 
@@ -138,8 +148,9 @@ func root(w http.ResponseWriter, r *http.Request) {
 	respBodyRC := ioutil.NopCloser(bytes.NewReader(encodedContent))
 	err = wfs3.ValidateJSONResponse(r, rPath, 200, w.Header(), respBodyRC)
 	if err != nil {
-		log.Printf(fmt.Sprintf("%v", err))
+		log.Printf("%v", err)
 		jsonError(w, "response doesn't match schema", 500)
+		log.Printf("*** DELETEME\n---\n%v\n---\n", string(encodedContent))
 		return
 	}
 
@@ -198,7 +209,7 @@ func openapi(w http.ResponseWriter, r *http.Request) {
 
 	var encodedContent []byte
 	if ct == JSONContentType {
-		encodedContent = wfs3.OpenAPI3SchemaJSON
+		encodedContent = wfs3.OpenAPI3SchemaJSON()
 	} else {
 		jsonError(w, "Content-Type: ''"+ct+"'' not supported.", 500)
 		return
@@ -235,7 +246,7 @@ func collectionMetaData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	md, err := wfs3.CollectionMetaData(cName, &Provider, serveAddress)
+	md, err := wfs3.CollectionMetaData(cName, &Provider, serveAddress(r))
 	if err != nil {
 		jsonError(w, err.Error(), 500)
 		return
@@ -278,7 +289,7 @@ func collectionsMetaData(w http.ResponseWriter, r *http.Request) {
 	overrideContent := r.Context().Value("overrideContent")
 
 	ct := contentType(r)
-	md, err := wfs3.CollectionsMetaData(&Provider, serveAddress)
+	md, err := wfs3.CollectionsMetaData(&Provider, serveAddress(r))
 	if err != nil {
 		jsonError(w, err.Error(), 500)
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -30,20 +30,26 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/go-spatial/go-wfs/config"
 	"github.com/go-spatial/go-wfs/data_provider"
 )
 
 var Provider data_provider.Provider
 
-var bindAddress string
-var serveAddress string
-
-func StartServer(setBindAddress, setServeAddress string, p data_provider.Provider) {
-	bindAddress = setBindAddress
-	serveAddress = setServeAddress
+func StartServer(p data_provider.Provider) {
+	sconf := config.Configuration.Server
+	var bindAddress string
+	if sconf.BindPort != 80 && sconf.BindPort != 443 {
+		bindAddress = fmt.Sprintf("%v:%v", sconf.BindHost, sconf.BindPort)
+	} else {
+		bindAddress = sconf.BindHost
+	}
 
 	fmt.Printf("Bound to: %v\n", bindAddress)
-	fmt.Printf("Expecting traffic at %v\n", serveAddress)
+	if sconf.Address != "" {
+		fmt.Printf("Expecting traffic at %v\n", sconf.Address)
+	}
+
 	Provider = p
 	handler := setUpRoutes()
 	err := http.ListenAndServe(bindAddress, handler)

--- a/wfs3/openapi3.go
+++ b/wfs3/openapi3.go
@@ -30,16 +30,31 @@ package wfs3
 
 import (
 	"encoding/json"
+	"log"
 
 	"github.com/go-spatial/go-wfs/config"
 	"github.com/jban332/kin-openapi/openapi3"
 )
 
-var OpenAPI3Schema openapi3.Swagger
-var OpenAPI3SchemaJSON []byte
+var openAPI3Schema *openapi3.Swagger
+var openAPI3SchemaJSON []byte
+
+func OpenAPI3Schema() *openapi3.Swagger {
+	if openAPI3Schema == nil {
+		GenerateOpenAPIDocument()
+	}
+	return openAPI3Schema
+}
+
+func OpenAPI3SchemaJSON() []byte {
+	if openAPI3SchemaJSON == nil {
+		GenerateOpenAPIDocument()
+	}
+	return openAPI3SchemaJSON
+}
 
 func GenerateOpenAPIDocument() {
-	OpenAPI3Schema = openapi3.Swagger{
+	openAPI3Schema = &openapi3.Swagger{
 		OpenAPI: "3.0.0",
 		Info: openapi3.Info{
 			Title:       config.Configuration.Metadata.Identification.Title,
@@ -241,11 +256,10 @@ func GenerateOpenAPIDocument() {
 		},
 	}
 
-	schemaJSON, err := json.Marshal(OpenAPI3Schema)
+	schemaJSON, err := json.Marshal(openAPI3Schema)
 	if err != nil {
-		// TODO: log error
-		schemaJSON = []byte("{}")
+		log.Printf("Problem marshalling openapi3 schema: %v", err)
 	}
 
-	OpenAPI3SchemaJSON = schemaJSON
+	openAPI3SchemaJSON = schemaJSON
 }

--- a/wfs3/validation.go
+++ b/wfs3/validation.go
@@ -16,10 +16,10 @@ func ValidateJSONResponse(request *http.Request, path string, status int, header
 	var op *openapi3.Operation
 	switch request.Method {
 	case "GET":
-		if OpenAPI3Schema.Paths[path] == nil {
+		if OpenAPI3Schema().Paths[path] == nil {
 			return fmt.Errorf("Path not found in schema: '%v'", path)
 		}
-		op = OpenAPI3Schema.Paths[path].Get
+		op = OpenAPI3Schema().Paths[path].Get
 	default:
 		return fmt.Errorf("unsupported request.Method: %v", request.Method)
 	}
@@ -27,7 +27,7 @@ func ValidateJSONResponse(request *http.Request, path string, status int, header
 	rvi := openapi3filter.RequestValidationInput{
 		Request: request,
 		Route: &openapi3filter.Route{
-			Swagger:   &OpenAPI3Schema,
+			Swagger:   OpenAPI3Schema(),
 			Server:    &openapi3.Server{},
 			Path:      path,
 			PathItem:  &openapi3.PathItem{},


### PR DESCRIPTION
Eliminated server vars "bindAddress" & "serveAddress". 

Wired config use into handlers.

Updated handlers to use request address if config Server.Address is not set.

Resolves #35. 