### PR TITLE
add CORS suport for GET & HEAD methods for all domains (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,20 @@ server/
   routes.go: maps urls to functions (from handlers.go)
   handlers.go: actual work done here
   server.go: simple interface to start the server.
-  openapi.go: encapsulates generation of json OpenAPI document for WFS service.
 
-provider/
-  provider.go: wraps github.com/go-spatial/tegola/provider.Tiler to provide convenience methods & additional behavior
+wfs3/
+  collection_meta_data.go: generates content for metadata requests
+  conformance.go: generates content for conformance requests
+  FeatureCollectionJSONSchema: provides a string variable populated with the schema for a geojson FeatureCollection
+  features.go: generates content for feature data requests
+  FeatureSchema.go: provides a string variable populated with the schema for a geojson Feature
+  openapi3.go: encapsulates generation of json OpenAPI3 document for WFS service.
+  root.go: generates content for a root path ("/") request
+  validation.go: helper functions for validating encoded responses
+  wfs3_types.go: go structs to mirror the types & their schemas specified in the wfs3 spec.
+
+data_provider/
+  provider.go: wraps `github.com/go-spatial/tegola/provider.Tiler` to provide convenience methods & additional behavior
 
 main.go: Executable entry-point.
 
@@ -31,6 +41,8 @@ git checkout v0.7.0
 # install other supporting packages
 go get github.com/jban332/kin-openapi/openapi3
 go get github.com/julienschmidt/httprouter
+go get github.com/rs/cors
+
 # install go-wfs
 go get github.com/go-spatial/go-wfs
 ```

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -219,13 +219,19 @@ func openapi(w http.ResponseWriter, r *http.Request) {
 	if overrideContent != nil {
 		encodedContent = overrideContent.([]byte)
 	}
-	// --- TODO: Disabled due to #34
-	// respBodyRC := ioutil.NopCloser(bytes.NewReader(encodedContent))
-	// err := wfs3.ValidateJSONResponse(r, oapiPath, 200, w.Header(), respBodyRC)
-	// if err != nil {
-	// 	log.Printf(fmt.Sprintf("%v", err))
-	// 	jsonError(w, "response doesn't match schema", 500)
-	// 	return
+
+	// TODO: As of 2018-04-05 I can't find a reliable openapi3 document schema.  When one is published use if for validation here.
+	// if ct == JSONContentType {
+	// 	err := wfs3.ValidateJSONResponseAgainstJSONSchema(encodedContent, jsonSchema)
+	// 	if err != nil {
+	// 		log.Printf(fmt.Sprintf("%v", err))
+	// 		jsonError(w, "response doesn't match schema", 500)
+	// 		return
+	// 	}
+	// } else {
+	// 	msg := fmt.Sprintf("unsupported content type: %v", ct)
+	// 	log.Printf(msg)
+	// 	jsonError(w, msg, 400)
 	// }
 
 	w.WriteHeader(200)

--- a/server/handlers_internal_test.go
+++ b/server/handlers_internal_test.go
@@ -91,11 +91,14 @@ func TestServeAddress(t *testing.T) {
 		},
 	}
 
+	originalServerAddress := config.Configuration.Server.Address
 	for i, tc := range testCases {
 		url := fmt.Sprintf("http://%v", tc.requestHost)
 		req := httptest.NewRequest("GET", url, bytes.NewReader([]byte{}))
 		if tc.serverConfigAddress != "" {
 			config.Configuration.Server.Address = tc.serverConfigAddress
+			// Restore the config change so other tests aren't affected.
+			defer func(osa string) { config.Configuration.Server.Address = osa }(originalServerAddress)
 		}
 		sa := serveAddress(req)
 		if sa != tc.expectedServeAddress {
@@ -193,7 +196,8 @@ func TestRoot(t *testing.T) {
 
 		body, _ := ioutil.ReadAll(resp.Body)
 		if string(body) != string(expectedContent) {
-			t.Errorf("\n%v\n--- != ---\n%v", string(body), string(expectedContent))
+			t.Errorf("[%v] response body doesn't match expected", i)
+			reducedOutputError(t, body, expectedContent)
 		}
 	}
 }
@@ -379,7 +383,7 @@ func TestCollectionsMetaData(t *testing.T) {
 		}
 
 		if string(body) != string(expectedContent) {
-			t.Errorf("[%v] response content doesn't match expected")
+			t.Errorf("[%v] response content doesn't match expected", i)
 			reducedOutputError(t, body, expectedContent)
 		}
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -32,19 +32,23 @@ import (
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/rs/cors"
 )
 
 func setUpRoutes() http.Handler {
 	r := httprouter.New()
+	c := cors.New(cors.Options{
+		AllowedMethods: []string{"GET", "HEAD"},
+	})
 
-	r.HandlerFunc("GET", "/", root)
-	r.HandlerFunc("GET", "/conformance", conformance)
-	r.HandlerFunc("GET", "/api", openapi)
+	r.Handler("GET", "/", c.Handler(http.HandlerFunc(root)))
+	r.Handler("GET", "/conformance", c.Handler(http.HandlerFunc(conformance)))
+	r.Handler("GET", "/api", c.Handler(http.HandlerFunc(openapi)))
 
-	r.HandlerFunc("GET", "/collections", collectionsMetaData)
-	r.HandlerFunc("GET", "/collections/:name", collectionMetaData)
-	r.HandlerFunc("GET", "/collections/:name/items", collectionData)
-	r.HandlerFunc("GET", "/collections/:name/items/:feature_id", collectionData)
+	r.Handler("GET", "/collections", c.Handler(http.HandlerFunc(collectionsMetaData)))
+	r.Handler("GET", "/collections/:name", c.Handler(http.HandlerFunc(collectionMetaData)))
+	r.Handler("GET", "/collections/:name/items", c.Handler(http.HandlerFunc(collectionData)))
+	r.Handler("GET", "/collections/:name/items/:feature_id", c.Handler(http.HandlerFunc(collectionData)))
 
 	return r
 }


### PR DESCRIPTION
The CORS stuff is focused in server/routes.go, plus some other fixups while getting that done.