### PR TITLE
ETag support

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -55,6 +55,7 @@ const (
 	HTTPStatusServerError = 500
 	HTTPStatusClientError = 400
 
+	HTTPMethodGET  = "GET"
 	HTTPMethodHEAD = "HEAD"
 )
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -122,7 +122,13 @@ func root(w http.ResponseWriter, r *http.Request) {
 	// This allows tests to set the result to whatever they want.
 	overrideContent := r.Context().Value("overrideContent")
 
-	rootContent := wfs3.Root(serveAddress(r))
+	rootContent, contentId := wfs3.Root(serveAddress(r), false)
+	w.Header().Set("ETag", contentId)
+	if r.Method == "HEAD" && r.Header.Get("ETag") == contentId {
+		w.WriteHeader(304)
+		return
+	}
+
 	ct := contentType(r)
 	rootContent.ContentType(ct)
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -287,9 +287,19 @@ func collectionMetaData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	md, err := wfs3.CollectionMetaData(cName, &Provider, serveAddress(r))
+	md, contentId, err := wfs3.CollectionMetaData(cName, &Provider, serveAddress(r), false)
 	if err != nil {
 		jsonError(w, err.Error(), HTTPStatusServerError)
+		return
+	}
+
+	w.Header().Set("ETag", contentId)
+	if r.Method == HTTPMethodHEAD {
+		if r.Header.Get("ETag") == contentId {
+			w.WriteHeader(HTTPStatusNotModified)
+		} else {
+			w.WriteHeader(HTTPStatusOk)
+		}
 		return
 	}
 
@@ -330,9 +340,19 @@ func collectionsMetaData(w http.ResponseWriter, r *http.Request) {
 	overrideContent := r.Context().Value("overrideContent")
 
 	ct := contentType(r)
-	md, err := wfs3.CollectionsMetaData(&Provider, serveAddress(r))
+	md, contentId, err := wfs3.CollectionsMetaData(&Provider, serveAddress(r), false)
 	if err != nil {
 		jsonError(w, err.Error(), HTTPStatusServerError)
+		return
+	}
+
+	w.Header().Set("ETag", contentId)
+	if r.Method == HTTPMethodHEAD {
+		if r.Header.Get("ETag") == contentId {
+			w.WriteHeader(HTTPStatusNotModified)
+		} else {
+			w.WriteHeader(HTTPStatusOk)
+		}
 		return
 	}
 

--- a/server/handlers_internal_test.go
+++ b/server/handlers_internal_test.go
@@ -502,6 +502,7 @@ func TestCollectionFeatures(t *testing.T) {
 		goContent          interface{}
 		contentOverride    interface{}
 		contentType        string
+		expectedETag       string
 		expectedStatusCode int
 		urlParams          map[string]string
 	}
@@ -717,6 +718,7 @@ func TestCollectionFeatures(t *testing.T) {
 			},
 			contentOverride:    nil,
 			contentType:        JSONContentType,
+			expectedETag:       "953ff7048ec325ce",
 			expectedStatusCode: 200,
 			urlParams: map[string]string{
 				"name": "aviation_polygons",
@@ -759,6 +761,14 @@ func TestCollectionFeatures(t *testing.T) {
 			t.Errorf("[%v] problem reading response body: %v", i, err)
 		}
 
+		if tc.expectedETag != "" && (resp.Header.Get("ETag") != tc.expectedETag) {
+			t.Errorf("[%v] ETag %v != %v", i, resp.Header.Get("ETag"), tc.expectedETag)
+		}
+
+		if resp.StatusCode != tc.expectedStatusCode {
+			t.Errorf("[%v] ETag %v != %v", i, resp.Header.Get("ETag"), tc.expectedETag)
+		}
+
 		if string(body) != string(expectedContent) {
 			t.Errorf("[%v] result doesn't match expected", i)
 			// bBuf := bytes.NewBufferString("")
@@ -777,6 +787,7 @@ func TestSingleCollectionFeature(t *testing.T) {
 		goContent          interface{}
 		contentOverride    interface{}
 		contentType        string
+		expectedETag       string
 		expectedStatusCode int
 		urlParams          map[string]string
 	}
@@ -802,6 +813,7 @@ func TestSingleCollectionFeature(t *testing.T) {
 			},
 			contentOverride:    nil,
 			contentType:        JSONContentType,
+			expectedETag:       "355e6572aaf34629",
 			expectedStatusCode: 200,
 			urlParams: map[string]string{
 				"name":       "roads_lines",
@@ -844,6 +856,14 @@ func TestSingleCollectionFeature(t *testing.T) {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			t.Errorf("[%v] problem reading response body: %v", i, err)
+		}
+
+		if tc.expectedETag != "" && (resp.Header.Get("ETag") != tc.expectedETag) {
+			t.Errorf("[%v] ETag %v != %v", i, resp.Header.Get("ETag"), tc.expectedETag)
+		}
+
+		if resp.StatusCode != tc.expectedStatusCode {
+			t.Errorf("[%v] ETag %v != %v", i, resp.Header.Get("ETag"), tc.expectedETag)
 		}
 
 		if string(body) != string(expectedContent) {

--- a/server/handlers_internal_test.go
+++ b/server/handlers_internal_test.go
@@ -143,7 +143,7 @@ func TestRoot(t *testing.T) {
 				},
 			},
 			contentType:        JSONContentType,
-			expectedETag:       "746573742e636f6dcbf29ce484222325",
+			expectedETag:       "34888c0b0c2a4a2c",
 			expectedStatusCode: 200,
 		},
 		// Schema error, Links type as []string instead of []wfs3.Link
@@ -358,6 +358,7 @@ func TestCollectionsMetaData(t *testing.T) {
 		goContent          interface{}
 		overrideContent    interface{}
 		contentType        string
+		expectedETag       string
 		expectedStatusCode int
 	}
 
@@ -366,6 +367,7 @@ func TestCollectionsMetaData(t *testing.T) {
 			goContent:          csInfo,
 			overrideContent:    nil,
 			contentType:        JSONContentType,
+			expectedETag:       "319a7aabe10f9760",
 			expectedStatusCode: 200,
 		},
 	}
@@ -395,6 +397,10 @@ func TestCollectionsMetaData(t *testing.T) {
 			t.Errorf("[%v] Problem reading response body: %v", i, err)
 		}
 
+		if tc.expectedETag != "" && (resp.Header.Get("ETag") != tc.expectedETag) {
+			t.Errorf("[%v] ETag %v != %v", i, resp.Header.Get("ETag"), tc.expectedETag)
+		}
+
 		if resp.StatusCode != tc.expectedStatusCode {
 			t.Errorf("[%v] Status code %v != %v", i, resp.StatusCode, tc.expectedStatusCode)
 		}
@@ -413,6 +419,7 @@ func TestSingleCollectionMetaData(t *testing.T) {
 		goContent          interface{}
 		contentOverride    interface{}
 		contentType        string
+		expectedETag       string
 		expectedStatusCode int
 		urlParams          map[string]string
 	}
@@ -431,6 +438,7 @@ func TestSingleCollectionMetaData(t *testing.T) {
 			},
 			contentOverride:    nil,
 			contentType:        JSONContentType,
+			expectedETag:       "cd9d017720aa82fd",
 			expectedStatusCode: 200,
 			urlParams:          map[string]string{"name": "roads_lines"},
 		},
@@ -468,6 +476,10 @@ func TestSingleCollectionMetaData(t *testing.T) {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			t.Errorf("[%v] Problem reading response body: %v", err)
+		}
+
+		if tc.expectedETag != "" && (resp.Header.Get("ETag") != tc.expectedETag) {
+			t.Errorf("[%v] ETag %v != %v", i, resp.Header.Get("ETag"), tc.expectedETag)
 		}
 		if resp.StatusCode != tc.expectedStatusCode {
 			t.Errorf("[%v] Status code %v != %v", resp.StatusCode, tc.expectedStatusCode)

--- a/server/handlers_internal_test.go
+++ b/server/handlers_internal_test.go
@@ -115,6 +115,7 @@ func TestRoot(t *testing.T) {
 		goContent          interface{}
 		overrideContent    interface{}
 		contentType        string
+		expectedETag       string
 		expectedStatusCode int
 	}
 
@@ -142,6 +143,7 @@ func TestRoot(t *testing.T) {
 				},
 			},
 			contentType:        JSONContentType,
+			expectedETag:       "746573742e636f6dcbf29ce484222325",
 			expectedStatusCode: 200,
 		},
 		// Schema error, Links type as []string instead of []wfs3.Link
@@ -192,6 +194,10 @@ func TestRoot(t *testing.T) {
 		// --- check that the results match expected
 		if resp.StatusCode != tc.expectedStatusCode {
 			t.Errorf("[%v]: status code %v != %v", i, resp.StatusCode, tc.expectedStatusCode)
+		}
+
+		if tc.expectedETag != "" && (resp.Header.Get("ETag") != tc.expectedETag) {
+			t.Errorf("[%v]: ETag %v != %v", i, resp.Header.Get("ETag"), tc.expectedETag)
 		}
 
 		body, _ := ioutil.ReadAll(resp.Body)

--- a/server/handlers_internal_test.go
+++ b/server/handlers_internal_test.go
@@ -271,6 +271,7 @@ func TestConformance(t *testing.T) {
 		goContent          interface{}
 		overrideContent    interface{}
 		contentType        string
+		expectedETag       string
 		expectedStatusCode int
 	}
 
@@ -284,6 +285,7 @@ func TestConformance(t *testing.T) {
 			},
 			overrideContent:    nil,
 			contentType:        JSONContentType,
+			expectedETag:       "4385e7a21a681d7d",
 			expectedStatusCode: 200,
 		},
 	}
@@ -310,6 +312,10 @@ func TestConformance(t *testing.T) {
 
 		if resp.StatusCode != tc.expectedStatusCode {
 			t.Errorf("status code %v != %v", resp.StatusCode, tc.expectedStatusCode)
+		}
+
+		if resp.Header.Get("ETag") != "" && (resp.Header.Get("ETag") != tc.expectedETag) {
+			t.Errorf("[%v] ETag %v != %v", i, resp.Header.Get("ETag"), tc.expectedETag)
 		}
 
 		body, err := ioutil.ReadAll(resp.Body)

--- a/server/handlers_internal_test.go
+++ b/server/handlers_internal_test.go
@@ -218,6 +218,7 @@ func TestApi(t *testing.T) {
 		goContent          interface{}
 		overrideContent    interface{}
 		contentType        string
+		expectedETag       string
 		expectedStatusCode int
 	}
 
@@ -226,6 +227,7 @@ func TestApi(t *testing.T) {
 			goContent:          wfs3.OpenAPI3Schema(),
 			overrideContent:    nil,
 			contentType:        JSONContentType,
+			expectedETag:       "3b6ca0c9c15e1720",
 			expectedStatusCode: 200,
 		},
 	}
@@ -255,6 +257,9 @@ func TestApi(t *testing.T) {
 			t.Errorf("[%v] status code %v != %v", i, resp.StatusCode, tc.expectedStatusCode)
 		}
 
+		if tc.expectedETag != "" && (resp.Header.Get("ETag") != tc.expectedETag) {
+			t.Errorf("[%v] ETag %v != %v", i, resp.Header.Get("ETag"), tc.expectedETag)
+		}
 		body, _ := ioutil.ReadAll(resp.Body)
 		if string(body) != string(expectedContent) {
 			t.Errorf("[%v] response content doesn't match expected:", i)

--- a/server/routes.go
+++ b/server/routes.go
@@ -42,13 +42,20 @@ func setUpRoutes() http.Handler {
 	})
 
 	r.Handler("GET", "/", c.Handler(http.HandlerFunc(root)))
+	r.Handler("HEAD", "/", c.Handler(http.HandlerFunc(root)))
 	r.Handler("GET", "/conformance", c.Handler(http.HandlerFunc(conformance)))
+	r.Handler("HEAD", "/conformance", c.Handler(http.HandlerFunc(conformance)))
 	r.Handler("GET", "/api", c.Handler(http.HandlerFunc(openapi)))
+	r.Handler("HEAD", "/api", c.Handler(http.HandlerFunc(openapi)))
 
 	r.Handler("GET", "/collections", c.Handler(http.HandlerFunc(collectionsMetaData)))
+	r.Handler("HEAD", "/collections", c.Handler(http.HandlerFunc(collectionsMetaData)))
 	r.Handler("GET", "/collections/:name", c.Handler(http.HandlerFunc(collectionMetaData)))
+	r.Handler("HEAD", "/collections/:name", c.Handler(http.HandlerFunc(collectionMetaData)))
 	r.Handler("GET", "/collections/:name/items", c.Handler(http.HandlerFunc(collectionData)))
+	r.Handler("HEAD", "/collections/:name/items", c.Handler(http.HandlerFunc(collectionData)))
 	r.Handler("GET", "/collections/:name/items/:feature_id", c.Handler(http.HandlerFunc(collectionData)))
+	r.Handler("HEAD", "/collections/:name/items/:feature_id", c.Handler(http.HandlerFunc(collectionData)))
 
 	return r
 }

--- a/wfs3/conformance.go
+++ b/wfs3/conformance.go
@@ -27,9 +27,17 @@
 
 package wfs3
 
+import (
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"log"
+)
+
 // --- Implements req/core/conformance-op
-func Conformance() *ConformanceClasses {
-	c := ConformanceClasses{
+func Conformance() (content *ConformanceClasses, contentId string) {
+	hasher := fnv.New64()
+	content = &ConformanceClasses{
 		ConformsTo: []string{
 			"http://www.opengis.net/spec/wfs-1/3.0/req/core",
 			"http://www.opengis.net/spec/wfs-1/3.0/req/geojson",
@@ -37,5 +45,14 @@ func Conformance() *ConformanceClasses {
 		},
 	}
 
-	return &c
+	byteContent, err := json.Marshal(content)
+	if err != nil {
+		log.Printf("Problem marshaling content inside Conformance(): %v", err)
+		return nil, ""
+	}
+
+	hasher.Write(byteContent)
+	contentId = fmt.Sprintf("%x", hasher.Sum64())
+
+	return content, contentId
 }

--- a/wfs3/features.go
+++ b/wfs3/features.go
@@ -2,38 +2,60 @@ package wfs3
 
 import (
 	"fmt"
+	"hash/fnv"
 
 	"github.com/go-spatial/go-wfs/data_provider"
 	"github.com/go-spatial/tegola/geom/encoding/geojson"
 )
 
-func Feature(cname string, fid uint64, p *data_provider.Provider) (*geojson.Feature, error) {
+func Feature(cname string, fid uint64, p *data_provider.Provider, checkOnly bool) (content *geojson.Feature, contentId string, err error) {
+	// TODO: This calculation of contentId assumes an unchanging data set.
+	// 	When a changing data set is needed this will have to be updated, hopefully after data providers can tell us
+	// 	something about updates.
+	hasher := fnv.New64()
+	hasher.Write([]byte(fmt.Sprintf("%v%v", cname, fid)))
+	contentId = fmt.Sprintf("%x", hasher.Sum64())
+
+	if checkOnly {
+		return nil, contentId, nil
+	}
+
 	pfs, err := p.GetFeatures(
 		[]data_provider.FeatureId{
 			{Collection: cname, FeaturePk: fid},
 		})
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	if len(pfs) != 1 {
-		return nil, fmt.Errorf("Invalid collection/fid: %v/%v", cname, fid)
+		return nil, "", fmt.Errorf("Invalid collection/fid: %v/%v", cname, fid)
 	}
 
 	pf := pfs[0]
-	gf := &geojson.Feature{
+	content = &geojson.Feature{
 		ID: &pf.ID, Geometry: geojson.Geometry{Geometry: pf.Geometry}, Properties: pf.Tags,
 	}
 
-	return gf, nil
+	return content, contentId, nil
 }
 
-func FeatureCollection(cName string, startIdx, stopIdx uint, p *data_provider.Provider) (
-	*geojson.FeatureCollection, error) {
+func FeatureCollection(cName string, startIdx, stopIdx uint, p *data_provider.Provider, checkOnly bool) (content *geojson.FeatureCollection, contentId string, err error) {
+	// TODO: This calculation of contentId assumes an unchanging data set.
+	// 	When a changing data set is needed this will have to be updated, hopefully after data providers can tell us
+	// 	something about updates.
+	hasher := fnv.New64()
+	hasher.Write([]byte(cName))
+	contentId = fmt.Sprintf("%x", hasher.Sum64())
+
+	if checkOnly {
+		return nil, contentId, nil
+	}
+
 	// all collection features
 	cfs, err := p.CollectionFeatures(cName, nil)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	uLenCfs := uint(len(cfs))
@@ -43,7 +65,7 @@ func FeatureCollection(cName string, startIdx, stopIdx uint, p *data_provider.Pr
 	}
 
 	if startIdx >= uLenCfs || stopIdx < startIdx {
-		return nil, fmt.Errorf(
+		return nil, "", fmt.Errorf(
 			"Invalid start/stop indices [%v, %v] for collection of length %v", startIdx, originalStopIdx, uLenCfs)
 	}
 
@@ -56,7 +78,7 @@ func FeatureCollection(cName string, startIdx, stopIdx uint, p *data_provider.Pr
 	}
 
 	// Wrap the features up in a FeatureCollection
-	fc := geojson.FeatureCollection{Features: gfs}
+	content = &geojson.FeatureCollection{Features: gfs}
 
-	return &fc, nil
+	return content, contentId, nil
 }

--- a/wfs3/openapi3.go
+++ b/wfs3/openapi3.go
@@ -30,6 +30,8 @@ package wfs3
 
 import (
 	"encoding/json"
+	"fmt"
+	"hash/fnv"
 	"log"
 
 	"github.com/go-spatial/go-wfs/config"
@@ -37,6 +39,7 @@ import (
 )
 
 var openAPI3Schema *openapi3.Swagger
+var openAPI3SchemaContentId string
 var openAPI3SchemaJSON []byte
 
 func OpenAPI3Schema() *openapi3.Swagger {
@@ -46,11 +49,17 @@ func OpenAPI3Schema() *openapi3.Swagger {
 	return openAPI3Schema
 }
 
-func OpenAPI3SchemaJSON() []byte {
+func OpenAPI3SchemaEncoded(encoding string) (encodedContent []byte, contentId string) {
 	if openAPI3SchemaJSON == nil {
 		GenerateOpenAPIDocument()
 	}
-	return openAPI3SchemaJSON
+
+	if encoding == "application/json" {
+		return openAPI3SchemaJSON, openAPI3SchemaContentId
+	} else {
+		msg := fmt.Sprintf("Encoding not supported: %v", encoding)
+		panic(msg)
+	}
 }
 
 func GenerateOpenAPIDocument() {
@@ -262,4 +271,8 @@ func GenerateOpenAPIDocument() {
 	}
 
 	openAPI3SchemaJSON = schemaJSON
+
+	hasher := fnv.New64()
+	hasher.Write(openAPI3SchemaJSON)
+	openAPI3SchemaContentId = fmt.Sprintf("%x", hasher.Sum64())
 }

--- a/wfs3/root.go
+++ b/wfs3/root.go
@@ -27,15 +27,27 @@
 
 package wfs3
 
-import "fmt"
+import (
+	"encoding/hex"
+	"fmt"
+	"hash/fnv"
+)
 
-func Root(serveAddress string) RootContent {
+// checkOnly indicates that the caller doesn't care about the content, only the contentId
+// contentId is a string that changes as the content changes, useful for ETag & caching.
+func Root(serveAddress string, checkOnly bool) (content *RootContent, contentId string) {
+	hasher := fnv.New64()
+	contentId = hex.EncodeToString(hasher.Sum([]byte(serveAddress)))
+	if checkOnly {
+		return nil, contentId
+	}
+
 	apiUrl := fmt.Sprintf("http://%v/api", serveAddress)
 	conformanceUrl := fmt.Sprintf("http://%v/conformance", serveAddress)
 	collectionsUrl := fmt.Sprintf("http://%v/collections", serveAddress)
 	selfUrl := fmt.Sprintf("http://%v/", serveAddress)
 
-	r := RootContent{
+	content = &RootContent{
 		Links: []*Link{
 			{
 				Href: selfUrl,
@@ -56,5 +68,5 @@ func Root(serveAddress string) RootContent {
 		},
 	}
 
-	return r
+	return content, contentId
 }

--- a/wfs3/root.go
+++ b/wfs3/root.go
@@ -28,7 +28,6 @@
 package wfs3
 
 import (
-	"encoding/hex"
 	"fmt"
 	"hash/fnv"
 )
@@ -37,7 +36,8 @@ import (
 // contentId is a string that changes as the content changes, useful for ETag & caching.
 func Root(serveAddress string, checkOnly bool) (content *RootContent, contentId string) {
 	hasher := fnv.New64()
-	contentId = hex.EncodeToString(hasher.Sum([]byte(serveAddress)))
+	hasher.Write([]byte(serveAddress))
+	contentId = fmt.Sprintf("%x", hasher.Sum64())
 	if checkOnly {
 		return nil, contentId
 	}


### PR DESCRIPTION
Add ETag headers to each http handler.
Update wfs3 content generators to provide a contentId of their result that only changes when the content changes.

The wiring is in place, but doesn't do much in terms of caching yet.  Punted a bit on the contentId generation assuming read-only as that's where we're at & I expect this will make its way down into the data provider.
