### PR TITLE
fix server address

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,7 @@ func init() {
 		Server: Server{
 			MimeType:    "application/json",
 			Encoding:    "utf8",
+			Scheme:      "http",
 			Language:    "en-US",
 			PrettyPrint: false,
 			Limit:       10,
@@ -82,7 +83,9 @@ func init() {
 type Server struct {
 	BindHost    string
 	BindPort    int
+	Scheme      string
 	Address     string
+	BaseURL     string
 	MimeType    string
 	Encoding    string
 	Language    string

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,8 @@ func init() {
 		Server: Server{
 			MimeType:    "application/json",
 			Encoding:    "utf8",
-			Scheme:      "http",
+			URLScheme:   "http",
+			URLBasePath: "/",
 			Language:    "en-US",
 			PrettyPrint: false,
 			Limit:       10,
@@ -81,11 +82,11 @@ func init() {
 
 // Config provides an object model for configuration.
 type Server struct {
-	BindHost    string
-	BindPort    int
-	Scheme      string
-	Address     string
-	BaseURL     string
+	BindHost    string `toml:"bind_host"`
+	BindPort    int    `toml:"bind_port"`
+	URLScheme   string `toml:"url_scheme"`
+	URLHostPort string `toml:"url_hostport"`
+	URLBasePath string `toml:"url_basepath"`
 	MimeType    string
 	Encoding    string
 	Language    string

--- a/go-wfs-config.toml
+++ b/go-wfs-config.toml
@@ -1,7 +1,9 @@
 [server]
   host = "localhost"
   port = 9000
-  address = "http://geo.kralidis.ca/go-wfs/"
+  scheme = "http"
+  address = "geo.kralidis.ca"
+  baseurl = "/go-wfs/"
   mimetype = "application/json; charset=UTF-8"
   encoding = "utf-8"
   language = "en-US"

--- a/go-wfs-config.toml
+++ b/go-wfs-config.toml
@@ -3,7 +3,7 @@
   port = 9000
   scheme = "http"
   address = "geo.kralidis.ca"
-  baseurl = "/go-wfs/"
+  #baseurl = "/go-wfs/"
   mimetype = "application/json; charset=UTF-8"
   encoding = "utf-8"
   language = "en-US"

--- a/go-wfs-config.toml
+++ b/go-wfs-config.toml
@@ -1,9 +1,9 @@
 [server]
-  host = "localhost"
-  port = 9000
-  scheme = "http"
-  address = "geo.kralidis.ca"
-  #baseurl = "/go-wfs/"
+  bind_host = "localhost"
+  bind_port = 9000
+  url_scheme = "http"
+  url_hostport = "geo.kralidis.ca"
+  url_basepath = "/go-wfs/"
   mimetype = "application/json; charset=UTF-8"
   encoding = "utf-8"
   language = "en-US"

--- a/go-wfs-config.toml
+++ b/go-wfs-config.toml
@@ -1,7 +1,7 @@
 [server]
   host = "localhost"
   port = 9000
-  url = "http://geo.kralidis.ca/go-wfs/"
+  address = "http://geo.kralidis.ca/go-wfs/"
   mimetype = "application/json; charset=UTF-8"
   encoding = "utf-8"
   language = "en-US"

--- a/main.go
+++ b/main.go
@@ -109,7 +109,10 @@ func main() {
 
 	config.Configuration.Server.BindHost = bindIp
 	config.Configuration.Server.BindPort = bindPort
-	config.Configuration.Server.Address = serveAddress
+
+	if serveAddress != "" {
+		config.Configuration.Server.Address = serveAddress
+	}
 
 	if dataSource != "" {
 		if _, err := os.Stat(config.Configuration.Providers.Data); os.IsNotExist(err) {

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func main() {
 	config.Configuration.Server.BindPort = bindPort
 
 	if serveAddress != "" {
-		config.Configuration.Server.Address = serveAddress
+		config.Configuration.Server.URLHostPort = serveAddress
 	}
 
 	if dataSource != "" {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -64,20 +64,16 @@ type HandlerError struct {
 }
 
 func serveAddress(r *http.Request) string {
-	psa := config.Configuration.Server.Address
-	if psa == "" {
-		psa = r.URL.Host
+	psh := config.Configuration.Server.URLHostPort
+	if psh == "" {
+		psh = r.URL.Host
 	}
 
-	psa = strings.TrimRight(psa, "/")
+	psh = strings.TrimRight(psh, "/")
 
-	if config.Configuration.Server.BaseURL != "" {
-		psa = fmt.Sprintf("%v://%v%v", config.Configuration.Server.Scheme, psa, strings.TrimRight(config.Configuration.Server.BaseURL, "/"))
-	} else {
-		psa = fmt.Sprintf("%v://%v", config.Configuration.Server.Scheme, psa)
-	}
+	psh = fmt.Sprintf("%v://%v%v", config.Configuration.Server.URLScheme, psh, strings.TrimRight(config.Configuration.Server.URLBasePath, "/"))
 
-	return psa
+	return psh
 }
 
 // contentType() returns the Content-Type string that will be used for the response to this request.

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -34,6 +34,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-spatial/go-wfs/config"
 	"github.com/go-spatial/go-wfs/wfs3"
@@ -66,6 +67,11 @@ func serveAddress(r *http.Request) string {
 	psa := config.Configuration.Server.Address
 	if psa == "" {
 		psa = r.URL.Host
+	}
+
+	endsWith := strings.HasSuffix(psa, "/")
+	if endsWith {
+		psa = strings.TrimRight(psa, "/")
 	}
 
 	return psa

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -69,9 +69,10 @@ func serveAddress(r *http.Request) string {
 		psa = r.URL.Host
 	}
 
-	endsWith := strings.HasSuffix(psa, "/")
-	if endsWith {
-		psa = strings.TrimRight(psa, "/")
+	psa = strings.TrimRight(psa, "/")
+
+	if config.Configuration.Server.BaseURL != "" {
+		psa = fmt.Sprintf("%v://%v%v", config.Configuration.Server.Scheme, psa, strings.TrimRight(config.Configuration.Server.BaseURL, "/"))
 	}
 
 	return psa

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -73,6 +73,8 @@ func serveAddress(r *http.Request) string {
 
 	if config.Configuration.Server.BaseURL != "" {
 		psa = fmt.Sprintf("%v://%v%v", config.Configuration.Server.Scheme, psa, strings.TrimRight(config.Configuration.Server.BaseURL, "/"))
+	} else {
+		psa = fmt.Sprintf("%v://%v", config.Configuration.Server.Scheme, psa)
 	}
 
 	return psa

--- a/server/handlers_internal_test.go
+++ b/server/handlers_internal_test.go
@@ -84,12 +84,12 @@ func TestServeAddress(t *testing.T) {
 		{
 			requestHost:          "someplace.com",
 			serverConfigAddress:  "",
-			expectedServeAddress: "someplace.com",
+			expectedServeAddress: "http://someplace.com",
 		},
 		{
 			requestHost:          "someplace.com",
 			serverConfigAddress:  "otherplace.com",
-			expectedServeAddress: "otherplace.com",
+			expectedServeAddress: "http://otherplace.com",
 		},
 	}
 
@@ -147,7 +147,7 @@ func TestRoot(t *testing.T) {
 				},
 			},
 			contentType:        JSONContentType,
-			expectedETag:       "34888c0b0c2a4a2c",
+			expectedETag:       "fed4927c1d9b340e",
 			expectedStatusCode: 200,
 		},
 		// Happy path HEAD test case
@@ -155,7 +155,7 @@ func TestRoot(t *testing.T) {
 			requestMethod:      HTTPMethodHEAD,
 			goContent:          nil,
 			contentType:        "",
-			expectedETag:       "34888c0b0c2a4a2c",
+			expectedETag:       "fed4927c1d9b340e",
 			expectedStatusCode: 200,
 		},
 		// Schema error, Links type as []string instead of []wfs3.Link
@@ -414,7 +414,7 @@ func TestCollectionsMetaData(t *testing.T) {
 			goContent:          csInfo,
 			overrideContent:    nil,
 			contentType:        JSONContentType,
-			expectedETag:       "319a7aabe10f9760",
+			expectedETag:       "86c51f1263aa1e87",
 			expectedStatusCode: 200,
 		},
 		// Happy-path HEAD request
@@ -422,7 +422,7 @@ func TestCollectionsMetaData(t *testing.T) {
 			requestMethod:      HTTPMethodHEAD,
 			goContent:          nil,
 			overrideContent:    nil,
-			expectedETag:       "319a7aabe10f9760",
+			expectedETag:       "86c51f1263aa1e87",
 			expectedStatusCode: 200,
 		},
 	}
@@ -489,6 +489,7 @@ func TestSingleCollectionMetaData(t *testing.T) {
 			requestMethod: HTTPMethodGET,
 			goContent: wfs3.CollectionInfo{
 				Name: "roads_lines",
+				Title: "roads_lines",
 				Links: []*wfs3.Link{
 					{
 						Rel:  "self",
@@ -499,7 +500,7 @@ func TestSingleCollectionMetaData(t *testing.T) {
 			},
 			contentOverride:    nil,
 			contentType:        JSONContentType,
-			expectedETag:       "cd9d017720aa82fd",
+			expectedETag:       "a3020c6917d284ef",
 			expectedStatusCode: 200,
 			urlParams:          map[string]string{"name": "roads_lines"},
 		},
@@ -508,7 +509,7 @@ func TestSingleCollectionMetaData(t *testing.T) {
 			requestMethod:      HTTPMethodHEAD,
 			goContent:          nil,
 			contentOverride:    nil,
-			expectedETag:       "cd9d017720aa82fd",
+			expectedETag:       "a3020c6917d284ef",
 			expectedStatusCode: 200,
 			urlParams:          map[string]string{"name": "roads_lines"},
 		},

--- a/server/handlers_internal_test.go
+++ b/server/handlers_internal_test.go
@@ -93,14 +93,14 @@ func TestServeAddress(t *testing.T) {
 		},
 	}
 
-	originalServerAddress := config.Configuration.Server.Address
+	originalServerAddress := config.Configuration.Server.URLHostPort
 	for i, tc := range testCases {
 		url := fmt.Sprintf("http://%v", tc.requestHost)
 		req := httptest.NewRequest("GET", url, bytes.NewReader([]byte{}))
 		if tc.serverConfigAddress != "" {
-			config.Configuration.Server.Address = tc.serverConfigAddress
+			config.Configuration.Server.URLHostPort = tc.serverConfigAddress
 			// Restore the config change so other tests aren't affected.
-			defer func(osa string) { config.Configuration.Server.Address = osa }(originalServerAddress)
+			defer func(osa string) { config.Configuration.Server.URLHostPort = osa }(originalServerAddress)
 		}
 		sa := serveAddress(req)
 		if sa != tc.expectedServeAddress {

--- a/server/server.go
+++ b/server/server.go
@@ -46,8 +46,8 @@ func StartServer(p data_provider.Provider) {
 	}
 
 	fmt.Printf("Bound to: %v\n", bindAddress)
-	if sconf.Address != "" {
-		fmt.Printf("Expecting traffic at %v\n", sconf.Address)
+	if sconf.URLHostPort != "" {
+		fmt.Printf("Expecting traffic at %v\n", sconf.URLHostPort)
 	}
 
 	Provider = p

--- a/wfs3/collection_meta_data.go
+++ b/wfs3/collection_meta_data.go
@@ -40,7 +40,7 @@ func CollectionsMetaData(p *data_provider.Provider, serveAddress string, checkOn
 	// 	When a changing data set is needed this will have to be updated, hopefully after data providers can tell us
 	// 	something about updates.
 	hasher := fnv.New64()
-	hasher.Write([]byte(fmt.Sprintf("%v%v", serveAddress)))
+	hasher.Write([]byte(fmt.Sprintf("%v", serveAddress)))
 	contentId = fmt.Sprintf("%x", hasher.Sum64())
 	if checkOnly {
 		return nil, contentId, nil
@@ -54,7 +54,7 @@ func CollectionsMetaData(p *data_provider.Provider, serveAddress string, checkOn
 
 	csInfo := CollectionsInfo{Links: []*Link{}, Collections: []*CollectionInfo{}}
 	for _, cn := range cNames {
-		collectionUrl := fmt.Sprintf("http://%v/collections/%v", serveAddress, cn)
+		collectionUrl := fmt.Sprintf("%v/collections/%v", serveAddress, cn)
 		cInfo := CollectionInfo{Name: cn, Links: []*Link{{Rel: "self", Href: collectionUrl}}}
 		cLink := Link{Href: collectionUrl, Rel: "item"}
 
@@ -93,8 +93,8 @@ func CollectionMetaData(name string, p *data_provider.Provider, serveAddress str
 		return nil, "", fmt.Errorf("Invalid collection name: %v", name)
 	}
 
-	collectionUrl := fmt.Sprintf("http://%v/collections/%v", serveAddress, name)
-	cInfo := CollectionInfo{Name: name, Links: []*Link{{Rel: "self", Href: collectionUrl}}}
+	collectionUrl := fmt.Sprintf("%v/collections/%v", serveAddress, name)
+	cInfo := CollectionInfo{Name: name, Title: name, Links: []*Link{{Rel: "self", Href: collectionUrl}}}
 
 	return &cInfo, contentId, nil
 }

--- a/wfs3/root.go
+++ b/wfs3/root.go
@@ -42,10 +42,10 @@ func Root(serveAddress string, checkOnly bool) (content *RootContent, contentId 
 		return nil, contentId
 	}
 
-	apiUrl := fmt.Sprintf("http://%v/api", serveAddress)
-	conformanceUrl := fmt.Sprintf("http://%v/conformance", serveAddress)
-	collectionsUrl := fmt.Sprintf("http://%v/collections", serveAddress)
-	selfUrl := fmt.Sprintf("http://%v/", serveAddress)
+	apiUrl := fmt.Sprintf("%v/api", serveAddress)
+	conformanceUrl := fmt.Sprintf("%v/conformance", serveAddress)
+	collectionsUrl := fmt.Sprintf("%v/collections", serveAddress)
+	selfUrl := fmt.Sprintf("%v/", serveAddress)
 
 	content = &RootContent{
 		Links: []*Link{


### PR DESCRIPTION
This PR fixes TOML config of `server.address` as well as normalize trailing slashes when creating endpoints.